### PR TITLE
feat: 新增v-model指令，支持数据双向绑定

### DIFF
--- a/src/APP.vue
+++ b/src/APP.vue
@@ -1,17 +1,22 @@
 <template>
   <div id="app">
-    <VueUEditor @ready="editorReady" style="width: 800px"></VueUEditor>
+    <VueUEditor @ready="editorReady" v-model="content" style="width: 800px"></VueUEditor>
   </div>
 </template>
 
 <script>
   import VueUEditor from './components/UEditor';
   export default {
+    data () {
+      return {
+        content: 'Hello world!<br>你可以在这里初始化编辑器的初始内容。'
+      };
+    },
     name: 'app',
     components: { VueUEditor },
     methods: {
       editorReady (editorInstance) {
-        editorInstance.setContent('Hello world!<br>你可以在这里初始化编辑器的初始内容。');
+        // editorInstance.setContent('Hello world!<br>你可以在这里初始化编辑器的初始内容。');
         editorInstance.addListener('contentChange', () => {
           console.log('编辑器内容发生了变化：', editorInstance.getContent());
         });

--- a/src/components/UEditor.vue
+++ b/src/components/UEditor.vue
@@ -5,6 +5,11 @@
 <script>
 export default {
   name: 'VueUEditor',
+  // 添加model，支持v-model指令
+  model: {
+    prop: 'content',
+    event: 'changeContent'
+  },
   props: {
     ueditorPath: {
       // UEditor 代码的路径
@@ -17,6 +22,10 @@ export default {
       default: function () {
         return {};
       }
+    },
+    content: {
+      type: String,
+      default: ''
     }
   },
   data () {
@@ -94,6 +103,16 @@ export default {
           // 绑定事件，当 UEditor 初始化完成后，将编辑器实例通过自定义的 ready 事件交出去
           this.instance.addListener('ready', () => {
             this.$emit('ready', this.instance);
+            // v-model指令初始化内容
+            if (this.content) {
+              this.instance.setContent(this.content);
+            }
+          });
+          // v-model指令更新内容
+          this.instance.addListener('contentChange', () => {
+            let ct = this.instance.getContent();
+            console.log(ct);
+            this.$emit('changeContent', ct);
           });
         });
       }


### PR DESCRIPTION
数据处理在已有的ready事件上，增加v-model指令，是数据更新更方便，减少代码量。
即现在支持两种数据处理的方式：

1. 使用 `ready` 事件：

    ```vue
    <VueUEditor  @ready="editorReady"/>
    ```

2. 类似于 `textarea` 元素一样，使用 `v-model` 指令：

    ```vue
    <VueUEditor  v-model="content"/>
    ```